### PR TITLE
fix: update diagnostic highlights

### DIFF
--- a/lua/nightfall/groups/integrations/lspconfig.lua
+++ b/lua/nightfall/groups/integrations/lspconfig.lua
@@ -50,34 +50,41 @@ function M.get(colors)
     ["@modifier"] = { fg = colors.lavender },
     ["@regexp"] = { fg = colors.pale_yellow },
 
-    -- Diagnostic Colors
-    DiagnosticError = {
+    -- Diagnostic Virtual Text Colors
+    DiagnosticVirtualTextError = {
       fg = colors.red,
       bg = utils.darken(colors.dark_navy, 0.95, colors.red),
       style = { italic = true },
     },
-    DiagnosticWarn = {
+    DiagnosticVirtualTextWarn = {
       fg = colors.pale_yellow,
       bg = utils.darken(colors.dark_navy, 0.95, colors.pale_yellow),
       style = { italic = true },
     },
-    DiagnosticInfo = {
+    DiagnosticVirtualTextInfo = {
       fg = colors.light_cyan,
       bg = utils.darken(colors.dark_navy, 0.95, colors.light_cyan),
       style = { italic = true },
     },
-    DiagnosticHint = {
+    DiagnosticVirtualTextHint = {
       fg = colors.violet,
       bg = utils.darken(colors.dark_navy, 0.95, colors.violet),
       style = { italic = true },
     },
-    DiagnosticOk = {
+    DiagnosticVirtualTextOk = {
       fg = colors.green,
       bg = utils.darken(colors.dark_navy, 0.95, colors.green),
       style = { italic = true },
     },
 
-    --  Diagnostic Underline Colors
+    -- Diagnostic Colors
+    DiagnosticError = { fg = colors.red },
+    DiagnosticWarn = { fg = colors.pale_yellow },
+    DiagnosticInfo = { fg = colors.light_cyan },
+    DiagnosticHint = { fg = colors.violet },
+    DiagnosticOk = { fg = colors.green },
+
+    -- Diagnostic Underline Colors
     DiagnosticUnderlineError = { sp = colors.red, style = { undercurl = true } },
     DiagnosticUnderlineWarn = { sp = colors.pale_yellow, style = { undercurl = true } },
     DiagnosticUnderlineInfo = { sp = colors.light_cyan, style = { undercurl = true } },

--- a/lua/nightfall/groups/integrations/lspconfig.lua
+++ b/lua/nightfall/groups/integrations/lspconfig.lua
@@ -51,11 +51,6 @@ function M.get(colors)
     ["@regexp"] = { fg = colors.pale_yellow },
 
     -- Diagnostic Colors
-    DiagnosticHint = {
-      fg = colors.violet,
-      bg = utils.darken(colors.dark_navy, 0.95, colors.violet),
-      style = { italic = true },
-    },
     DiagnosticError = {
       fg = colors.red,
       bg = utils.darken(colors.dark_navy, 0.95, colors.red),
@@ -71,18 +66,37 @@ function M.get(colors)
       bg = utils.darken(colors.dark_navy, 0.95, colors.light_cyan),
       style = { italic = true },
     },
+    DiagnosticHint = {
+      fg = colors.violet,
+      bg = utils.darken(colors.dark_navy, 0.95, colors.violet),
+      style = { italic = true },
+    },
+    DiagnosticOk = {
+      fg = colors.green,
+      bg = utils.darken(colors.dark_navy, 0.95, colors.green),
+      style = { italic = true },
+    },
 
-    -- Floating Diagnostic Colors
+    --  Diagnostic Underline Colors
+    DiagnosticUnderlineError = { sp = colors.red, style = { undercurl = true } },
+    DiagnosticUnderlineWarn = { sp = colors.pale_yellow, style = { undercurl = true } },
+    DiagnosticUnderlineInfo = { sp = colors.light_cyan, style = { undercurl = true } },
+    DiagnosticUnderlineHint = { sp = colors.violet, style = { undercurl = true } },
+    DiagnosticUnderlineOk = { sp = colors.green, style = { undercurl = true } },
+
+    -- Diagnostic Floating Colors
     DiagnosticFloatingError = { fg = colors.red },
     DiagnosticFloatingWarn = { fg = colors.pale_yellow },
     DiagnosticFloatingInfo = { fg = colors.light_cyan },
     DiagnosticFloatingHint = { fg = colors.violet },
+    DiagnosticFloatingOk = { fg = colors.green },
 
     -- Diagnostic Sign Colors
     DiagnosticSignError = { fg = colors.red },
     DiagnosticSignWarn = { fg = colors.pale_yellow },
     DiagnosticSignInfo = { fg = colors.light_cyan },
     DiagnosticSignHint = { fg = colors.violet },
+    DiagnosticSignOk = { fg = colors.green },
 
     -- LSP Reference Colors
     LspReferenceText = { bg = colors.deep_navy },


### PR DESCRIPTION
Related: Did you originally want the generic `Diagnostic[Error|Warning|etc.]` to be italic and have a background color or was that meant for `DiagnosticVirtual[…]`? I think the majority of themes only give the latter a `bg`.

![diagnostic-hl](https://github.com/user-attachments/assets/08532848-656c-4505-b6e5-737807af6611)